### PR TITLE
Filter references for reply check

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -17,11 +17,11 @@ const client = new Discord.Client({
 const deletedMessages = new WeakSet();
 
 export function isMessageDeleted(message) {
-	return deletedMessages.has(message);
+  return deletedMessages.has(message);
 }
 
 export function markMessageAsDeleted(message) {
-	deletedMessages.add(message);
+  deletedMessages.add(message);
 }
 
 // Quick validation of whether a message was sent by Jahir or not
@@ -36,7 +36,7 @@ client.once('ready', () => {
   console.log('Discord bot is ready!!');
 });
 
-client.on('messageCreate', async (message) => {
+client.on('messageCreate', async message => {
   const { cleanContent: text = '', author = {}, authorId, type, reference } = message;
 
   if (reference != null) {
@@ -84,7 +84,7 @@ client.on('messageCreate', async (message) => {
   }
 });
 
-client.on('messageDelete', async (message) => {
+client.on('messageDelete', async message => {
   markMessageAsDeleted(message);
 });
 

--- a/discord.js
+++ b/discord.js
@@ -29,18 +29,15 @@ client.once('ready', () => {
 client.on('message', async (message) => {
   const { cleanContent: text = '', author = {}, authorId, deleted, type, reference } = message;
 
-  /*
   if (reference != null) {
     const { messageId } = reference;
     const referencedMessage = await message.channel.messages.fetch(messageId).catch(console.error);
+    console.log(referencedMessage);
     if (referencedMessage) {
       const { type, authorId } = referencedMessage;
-      if (type == 'REPLY') {
-        // TODO: ??
-      }
+      var referenceToJahir = authorId === jahirUserId;
     }
   }
-  */
 
   if (type === 'PINS_ADD') {
     message.delete().catch(console.error);
@@ -61,7 +58,7 @@ client.on('message', async (message) => {
     return user.username === 'jahirfiquitiva';
   });
   if (mentionedJahir) {
-    if (!jahirSentMessage(actualAuthor, author)) {
+    if (!jahirSentMessage(actualAuthor, author) && !referenceToJahir) {
       message.reply(
         `Please don't mention Jahir; he checks this server regularly and will get back to you as soon as he can.`
       );

--- a/discord.js
+++ b/discord.js
@@ -26,7 +26,7 @@ client.once('ready', () => {
   console.log('Discord bot is ready!!');
 });
 
-client.on('message', async (message) => {
+client.on('messageCreate', async (message) => {
   const { cleanContent: text = '', author = {}, authorId, deleted, type, reference } = message;
 
   if (reference != null) {


### PR DESCRIPTION
This will check if there was a reference (in Discord the Reply feature) where Jahir is the starter. Such replies have a hidden tag to the writer, and this would trigger the bot to send the mention warning. With this filter, it won't do that anymore.

If this filter doesn't catch all the cases, we can later just check if the message is a reference in general and just skip it, but I don't think that would be necessary.

I've also updated some deprecated code, on request in #3.

This will close #3.